### PR TITLE
Proposal: ERC721Mutable

### DIFF
--- a/contracts/Blockheads.sol
+++ b/contracts/Blockheads.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./ERC2981ContractWideRoyalties.sol";
+import "./IERC721Mutable.sol";
 import "./Utils.sol";
 import "./ERC721Tradable.sol";
 
@@ -72,9 +73,7 @@ interface IERC20 {
     function balanceOf(address account) external view returns (uint256);
 }
 
-contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties {
-    event BlockheadReconfigured(uint256 tokenId);
-
+contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Mutable {
     // Max there will ever be available
     uint256 public constant totalAvailable = 10000;
     // currentlyAvailable for releasing in batches
@@ -343,8 +342,8 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties {
             overrides[token1].headwearOverridden = true;
             overrides[token2].headwearOverridden = true;
         }
-        emit BlockheadReconfigured(token1);
-        emit BlockheadReconfigured(token2);
+        emit TokenMetadataChanged(token1, tokenMetadataHash(token1));
+        emit TokenMetadataChanged(token2, tokenMetadataHash(token2));
     }
 
     function swapProfessions(uint256 token1, uint256 token2)
@@ -357,8 +356,8 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties {
         professionOverrides[token2].profession = newProfession2;
         professionOverrides[token1].overridden = true;
         professionOverrides[token2].overridden = true;
-        emit BlockheadReconfigured(token1);
-        emit BlockheadReconfigured(token2);
+        emit TokenMetadataChanged(token1, tokenMetadataHash(token1));
+        emit TokenMetadataChanged(token2, tokenMetadataHash(token2));
     }
 
     function setName(uint256 tokenId, string memory name) public {
@@ -368,7 +367,7 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties {
         birthRegistry[nameOverrides[tokenId]] = false;
         nameOverrides[tokenId] = name;
         birthRegistry[name] = true;
-        emit BlockheadReconfigured(tokenId);
+        emit TokenMetadataChanged(tokenId, tokenMetadataHash(tokenId));
     }
 
     function getName(uint256 tokenId) public view returns (string memory) {
@@ -510,6 +509,18 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties {
             )
         );
         return string(abi.encodePacked("data:application/json;base64,", json));
+    }
+
+    function tokenMetadataHash(uint256 _tokenId) public view override returns (uint256) {
+        return uint256(keccak256(abi.encode(
+            backgroundIndex(_tokenId),
+            bodyIndex(_tokenId),
+            armsIndex(_tokenId),
+            headIndex(_tokenId),
+            faceIndex(_tokenId),
+            headwearIndex(_tokenId),
+            getName(_tokenId)
+        )));
     }
 
     function getBgData(uint256 tokenId) public view returns (bytes memory) {

--- a/contracts/Blockheads.sol
+++ b/contracts/Blockheads.sol
@@ -342,8 +342,10 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
             overrides[token1].headwearOverridden = true;
             overrides[token2].headwearOverridden = true;
         }
-        emit TokenMetadataChanged(token1, tokenMetadataHash(token1));
-        emit TokenMetadataChanged(token2, tokenMetadataHash(token2));
+        (uint256 metadataHash1,) = tokenMetadataHash(token1);
+        (uint256 metadataHash2,) = tokenMetadataHash(token2);
+        emit TokenMetadataChanged(token1, metadataHash1, 0);
+        emit TokenMetadataChanged(token2, metadataHash2, 0);
     }
 
     function swapProfessions(uint256 token1, uint256 token2)
@@ -356,8 +358,10 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
         professionOverrides[token2].profession = newProfession2;
         professionOverrides[token1].overridden = true;
         professionOverrides[token2].overridden = true;
-        emit TokenMetadataChanged(token1, tokenMetadataHash(token1));
-        emit TokenMetadataChanged(token2, tokenMetadataHash(token2));
+        (uint256 metadataHash1,) = tokenMetadataHash(token1);
+        (uint256 metadataHash2,) = tokenMetadataHash(token2);
+        emit TokenMetadataChanged(token1, metadataHash1, 0);
+        emit TokenMetadataChanged(token2, metadataHash2, 0);
     }
 
     function setName(uint256 tokenId, string memory name) public {
@@ -367,7 +371,8 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
         birthRegistry[nameOverrides[tokenId]] = false;
         nameOverrides[tokenId] = name;
         birthRegistry[name] = true;
-        emit TokenMetadataChanged(tokenId, tokenMetadataHash(tokenId));
+        (uint256 metadataHash,) = tokenMetadataHash(tokenId);
+        emit TokenMetadataChanged(tokenId, metadataHash, 0);
     }
 
     function getName(uint256 tokenId) public view returns (string memory) {
@@ -511,8 +516,8 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
         return string(abi.encodePacked("data:application/json;base64,", json));
     }
 
-    function tokenMetadataHash(uint256 _tokenId) public view override returns (uint256) {
-        return uint256(keccak256(abi.encode(
+    function tokenMetadataHash(uint256 _tokenId) public view override returns (uint256, uint256) {
+        return (uint256(keccak256(abi.encode(
             backgroundIndex(_tokenId),
             bodyIndex(_tokenId),
             armsIndex(_tokenId),
@@ -520,7 +525,7 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
             faceIndex(_tokenId),
             headwearIndex(_tokenId),
             getName(_tokenId)
-        )));
+        ))), 0);
     }
 
     function getBgData(uint256 tokenId) public view returns (bytes memory) {

--- a/contracts/IERC721Mutable.sol
+++ b/contracts/IERC721Mutable.sol
@@ -11,10 +11,11 @@ interface IERC721Mutable {
     ///         Marketplaces should expire offers if the metadata has changed after the offer was placed.
     /// @param _tokenId - the NFT asset queried
     /// @return _metadataHash - the royalty payment amount for value sale price
+    /// @return _timeToLive - The amount of time the metadata is expected to be valid for, in seconds.  Return 0 for an infinite TTL if the metadata isn't time based, and only changes via external action.
     function tokenMetadataHash(uint256 _tokenId)
         external
         view
-        returns (uint256 _metadataHash);
+        returns (uint256 _metadataHash, uint256 _timeToLive);
 
-    event TokenMetadataChanged(uint256 _tokenId, uint256 _metadataHash);
+    event TokenMetadataChanged(uint256 _tokenId, uint256 _metadataHash, uint256 _timeToLive);
 }

--- a/contracts/IERC721Mutable.sol
+++ b/contracts/IERC721Mutable.sol
@@ -1,0 +1,20 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+/// @notice IERC721Mutable is a standard for managing ERC721 tokens with mutable metadata
+///         It is useful for both keeping metadata updated in indexed marketplaces as well as 
+///         preventing malicious sellers from accepting offers placed before changing the metadata.
+/// @title IERC721Mutable
+/// @dev Interface for the ERC721Mutable - Mutable Token Metadata standard
+interface IERC721Mutable {
+    /// @notice Returns a hash of the relevent metadata characteristics that should be taken into account for considering if an NFT has changed.
+    ///         Marketplaces should expire offers if the metadata has changed after the offer was placed.
+    /// @param _tokenId - the NFT asset queried
+    /// @return _metadataHash - the royalty payment amount for value sale price
+    function tokenMetadataHash(uint256 _tokenId)
+        external
+        view
+        returns (uint256 _metadataHash);
+
+    event TokenMetadataChanged(uint256 _tokenId, uint256 _metadataHash);
+}

--- a/contracts/IERC721Mutable.sol
+++ b/contracts/IERC721Mutable.sol
@@ -17,5 +17,5 @@ interface IERC721Mutable {
         view
         returns (uint256 _metadataHash, uint256 _timeToLive);
 
-    event TokenMetadataChanged(uint256 _tokenId, uint256 _metadataHash, uint256 _timeToLive);
+    event TokenMetadataChanged(uint256 indexed _tokenId, uint256 _metadataHash, uint256 _timeToLive);
 }

--- a/test/blockheads-test.ts
+++ b/test/blockheads-test.ts
@@ -266,6 +266,32 @@ describe("Blockheads", function () {
     expect(token2HeadAfter).to.equal(token2HeadBefore);
   });
 
+  it("Should emit an event and change metadata hash on swap", async function () {
+    const accounts = await ethers.getSigners();
+    const mainAccount = accounts[0];
+    await blockheads.mint({ value: ethers.utils.parseEther("0.12") });
+    await blockheads.mint({ value: ethers.utils.parseEther("0.12") });
+    const token1 = await blockheads.tokenOfOwnerByIndex(mainAccount.address, 0);
+    const token2 = await blockheads.tokenOfOwnerByIndex(
+      mainAccount.address,
+      1
+    );
+    const token1MetadataHashBefore = await blockheads.tokenMetadataHash(token1);
+    await 
+      expect(blockheads.swapParts(
+        token1,
+        token2,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false
+    )).to.emit(blockheads, "TokenMetadataChanged");
+    const token1MetadataHashAfter = await blockheads.tokenMetadataHash(token1);
+    expect(token1MetadataHashAfter).not.to.equal(token1MetadataHashBefore)
+  });
+
   it("Can be withdrawn by owning account", async function () {
     const accounts = await ethers.getSigners();
     const mainAccount = accounts[0];

--- a/test/blockheads-test.ts
+++ b/test/blockheads-test.ts
@@ -276,7 +276,7 @@ describe("Blockheads", function () {
       mainAccount.address,
       1
     );
-    const token1MetadataHashBefore = await blockheads.tokenMetadataHash(token1);
+    const [token1MetadataHashBefore] = await blockheads.tokenMetadataHash(token1);
     await 
       expect(blockheads.swapParts(
         token1,
@@ -288,7 +288,7 @@ describe("Blockheads", function () {
         false,
         false
     )).to.emit(blockheads, "TokenMetadataChanged");
-    const token1MetadataHashAfter = await blockheads.tokenMetadataHash(token1);
+    const [token1MetadataHashAfter] = await blockheads.tokenMetadataHash(token1);
     expect(token1MetadataHashAfter).not.to.equal(token1MetadataHashBefore)
   });
 


### PR DESCRIPTION
Mutable NFTs (tokens that can have their metadata/representation changed) have 2 issues with marketplaces:
- Marketplaces often index and cache metadata, so if something changes they will show stale data
- A malicious user could place a token with rare traits up for sale, and when an offer comes in swap out the rare piece for something else and then accept the offer.

I propose an ERC721Mutable extension to help support Mutable NFTs in the marketplace.  If this is useful i will make a real RFC

It solves the problem of stale data by emitting a standardized event that marketplaces can listen for to update their metadata cache.  We change the name to `TokenMetadataChanged` and add the token metadata hash to the event.

It solves the second problem by giving tokens a `tokenMetadataHash` that can be queried and offers can be scoped to a specific metadata hash.  If the hash is different when the seller tries to accept, the offer can be cancelled by the marketplace contract.

The metadata hash should only include properties that are representative of properties a user would expect to be placing an offer on.  Using a game character as an example it _would_ include body armor attached, but it would _not_ include a score that can only go up.  If something can be maliciously changed after the fact it should probably be included, but if something is expected to change and doesn't change the understanding of the token it should not, otherwise offers would be invalidated too often.
