### PR TITLE
Cross user swaps

### DIFF
--- a/contracts/Blockheads.sol
+++ b/contracts/Blockheads.sol
@@ -98,7 +98,9 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
     bytes32 public constant COUNTERPARTY_TYPEHASH =
         keccak256("Swap(uint256 tokenId,uint32 background,uint32 body,uint32 arms,uint32 head,uint32 face,uint32 headwear,uint16 nonce)");
 
-    struct SwapData {
+    // Used in swaps to specify the desired end result of a signature based
+    // cross user swap
+    struct BlockheadLayerState {
         uint32 background;
         uint32 body;
         uint32 arms;
@@ -333,8 +335,8 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
 
     // The indices for all layers of the token.  We can't just use overrides because
     // anything non-overridden will need to use initialValueFor
-    function layerValues(uint256 tokenId) public view returns (SwapData memory) {
-        return SwapData(
+    function layerValues(uint256 tokenId) public view returns (BlockheadLayerState memory) {
+        return BlockheadLayerState(
             backgroundIndex(tokenId),
             bodyIndex(tokenId),
             armsIndex(tokenId),
@@ -359,7 +361,7 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
         _doSwapParts(token1, token2, background, body, arms, heads, faces, headwear);
     }
 
-    function createDigest(uint256 token2, SwapData memory swapData) internal view returns (bytes32) {
+    function createDigest(uint256 token2, BlockheadLayerState memory swapData) internal view returns (bytes32) {
         // We need to ensure that the owner of token 2 signed a message approving the exact swap
         // that's trying to be performed.  We use the nonces to ensure the swap can't be performed twice.
         bytes32 digest = keccak256(

--- a/contracts/Blockheads.sol
+++ b/contracts/Blockheads.sol
@@ -382,11 +382,12 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
         bool faces,
         bool headwear) public {
             // The signature is for the final results so we attempt the swap and then verify
-            // that the other use has signed for the final results, and roll back if something else happened
+            // that the other user has signed for the final results, and roll back if something else happened
             _doSwapParts(token1, token2, background, body, arms, heads, faces, headwear);
             address otherOwner = ownerOf(token2);
             // We create a digest message that is packed exactly like we pack it on the client side, and then
             // recover the signature from it and expect it to match the other user.
+            // This digest should encode the post-swap state of the blockhead, and match what was signed for.
             bytes32 digest = createDigest(token2, layerValues(token2));
             address recoveredAddress = digest.recover(signature);
             require(recoveredAddress == otherOwner);

--- a/contracts/Blockheads.sol
+++ b/contracts/Blockheads.sol
@@ -340,7 +340,7 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
                 )
             );
             address recoveredAddress = digest.recover(signature);
-            require(recoveredAddress == otherOwner, "Invalid Signature");
+            require(recoveredAddress == otherOwner);
             _doSwapParts(token1, token2, background, body, arms, heads, faces, headwear);
         }
 

--- a/contracts/Blockheads.sol
+++ b/contracts/Blockheads.sol
@@ -89,7 +89,7 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
     // EIP-712 signing for swaps between different owners
     bytes32 public DOMAIN_SEPARATOR;
     bytes32 public constant COUNTERPARTY_TYPEHASH =
-        keccak256("Swap(uint256 ownersToken,uint256 otherToken,bool background,bool body,bool arms,bool head,bool face,bool headwear)");
+        keccak256("Swap(uint256 ownersToken,uint256 otherToken,bool background,bool body,bool arms,bool head,bool face,bool headwear,uint16 nonce)");
 
     /**
     Attributes can be referenced by an index into the labels and image data
@@ -332,11 +332,12 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
         bool faces,
         bool headwear) public {
             address otherOwner = ownerOf(token2);
+            uint16 nonce = overrides[token2].nonce;
             bytes32 digest = keccak256(
                 abi.encodePacked(
                     "\x19\x01",
                     DOMAIN_SEPARATOR,
-                    keccak256(abi.encode(COUNTERPARTY_TYPEHASH, token2, token1, background, body, arms, heads, faces, headwear))
+                    keccak256(abi.encode(COUNTERPARTY_TYPEHASH, token2, token1, background, body, arms, heads, faces, headwear, nonce))
                 )
             );
             address recoveredAddress = digest.recover(signature);

--- a/contracts/Blockheads.sol
+++ b/contracts/Blockheads.sol
@@ -91,7 +91,10 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
     // swap parts between two tokens that aren't owned by the same person.  UserA can swap with a token
     // owned by userB as long as userB provides a signature with the two token IDs and the swaps they wish
     // to approve.
+    // DOMAIN_SEPARATOR is static data included in the digest to be signed/verified defining this contract and deployment so that a signature 
+    // can't be used on a different contract or chain.
     bytes32 public DOMAIN_SEPARATOR;
+    // The TYPEHASH is the description of the shape of the data that needs to exactly match the shape of the data as we sign it.
     bytes32 public constant COUNTERPARTY_TYPEHASH =
         keccak256("Swap(uint256 ownersToken,uint256 otherToken,bool background,bool body,bool arms,bool head,bool face,bool headwear,uint16 nonce)");
 
@@ -409,6 +412,9 @@ contract Blockheads is ERC721Tradable, ERC2981ContractWideRoyalties, IERC721Muta
             overrides[token1].headwearOverridden = true;
             overrides[token2].headwearOverridden = true;
         }
+        // Nonces should be incremented even if we didn't use signatures.
+        // Once anything about the token is changed, any signatures should
+        // be invalidated.
         overrides[token1].nonce++;
         overrides[token2].nonce++;
         (uint256 metadataHash1,) = tokenMetadataHash(token1);

--- a/test/blockheads-test.ts
+++ b/test/blockheads-test.ts
@@ -187,7 +187,7 @@ describe("Blockheads", function () {
     );
     // Bump the nonce here so the nonces are different and we actually test that, rather than
     // them both being 0 and not being tested
-    await blockheads.bumpNonce(token1)
+    await blockheads.invalidateSignatures(token1)
     const token2 = await blockheads.tokenOfOwnerByIndex(
       otherAccount.address,
       0
@@ -236,7 +236,7 @@ describe("Blockheads", function () {
     );
     // Bump the nonce here so the nonces are different and we actually test that, rather than
     // them both being 0 and not being tested
-    await blockheads.bumpNonce(token1)
+    await blockheads.invalidateSignatures(token1)
     const token2 = await blockheads.tokenOfOwnerByIndex(
       otherAccount.address,
       0
@@ -290,7 +290,7 @@ describe("Blockheads", function () {
     );
     // Bump the nonce here so the nonces are different and we actually test that, rather than
     // them both being 0 and not being tested
-    await blockheads.bumpNonce(token1)
+    await blockheads.invalidateSignatures(token1)
     const token2 = await blockheads.tokenOfOwnerByIndex(
       otherAccount.address,
       0

--- a/test/blockheads-test.ts
+++ b/test/blockheads-test.ts
@@ -158,8 +158,6 @@ describe("Blockheads", function () {
       );
       let token1HeadBefore = await blockheads.headIndex(token1);
       let token2HeadBefore = await blockheads.headIndex(token2);
-      const token1BodyBefore = await blockheads.bodyIndex(token1);
-      const token2BodyBefore = await blockheads.bodyIndex(token2);
       await blockheads.swapParts(
         token1,
         token2,
@@ -172,12 +170,8 @@ describe("Blockheads", function () {
       );
       let token1HeadAfter = await blockheads.headIndex(token1);
       let token2HeadAfter = await blockheads.headIndex(token2);
-      const token1BodyAfter = await blockheads.bodyIndex(token1);
-      const token2BodyAfter = await blockheads.bodyIndex(token2);
       expect(token1HeadAfter).to.equal(token2HeadBefore);
       expect(token2HeadAfter).to.equal(token1HeadBefore);
-      // expect(token1BodyAfter).to.equal(token2BodyBefore);
-      // expect(token2BodyAfter).to.equal(token1BodyBefore);
     }
   });
 
@@ -198,37 +192,36 @@ describe("Blockheads", function () {
       otherAccount.address,
       0
     );
-    const nonce1 = (await blockheads.overrides.call(otherAccount, token1)).nonce
-    const nonce2 = (await blockheads.overrides.call(otherAccount, token2)).nonce
-    let token1HeadBefore = await blockheads.headIndex(token1);
-    let token2HeadBefore = await blockheads.headIndex(token2);
+    const token2Values = await blockheads.layerValues(token2)
     const token1BodyBefore = await blockheads.bodyIndex(token1);
     const token2BodyBefore = await blockheads.bodyIndex(token2);
-    const signature = await createSwapSignature(otherAccount, blockheads.address, token2, token1, {
-      background: false,
-      body: false,
-      head: true,
-      arms: false,
-      face: false,
-      headwear: false,
-      nonce1: BigNumber.from(nonce1),
-      nonce2: BigNumber.from(nonce2)
-    })
+    // Create a swap signature representing the final state where `otherAccount` requests
+    // the body index of token 1.
+    const desiredState = {
+      background: token2Values.background,
+      body: token1BodyBefore, // Take the body value from token1
+      head: token2Values.head,
+      arms: token2Values.arms,
+      face: token2Values.face,
+      headwear: token2Values.headwear,
+      nonce: token2Values.nonce + 1, // Since the signature should be for the final state, we need to use the incremented nonce
+    };
+    const signature = await createSwapSignature(otherAccount, blockheads.address, token2, desiredState)
     await blockheads.swapPartsCrossUser(
       token1,
       token2,
       signature,
       false,
-      false,
-      false,
       true,
+      false,
+      false,
       false,
       false
     );
-    let token1HeadAfter = await blockheads.headIndex(token1);
-    let token2HeadAfter = await blockheads.headIndex(token2);
-    expect(token1HeadAfter).to.equal(token2HeadBefore);
-    expect(token2HeadAfter).to.equal(token1HeadBefore);
+    let token1BodyAfter = await blockheads.bodyIndex(token1);
+    let token2BodyAfter = await blockheads.bodyIndex(token2);
+    expect(token1BodyAfter).to.equal(token2BodyBefore);
+    expect(token2BodyAfter).to.equal(token1BodyBefore);
   })
 
   it("Can't use the same signature twice", async function() {
@@ -248,38 +241,38 @@ describe("Blockheads", function () {
       otherAccount.address,
       0
     );
-    const nonce1 = (await blockheads.overrides.call(otherAccount, token1)).nonce
-    const nonce2 = (await blockheads.overrides.call(otherAccount, token2)).nonce
-    const signature = await createSwapSignature(otherAccount, blockheads.address, token2, token1, {
-      background: false,
-      body: false,
-      head: true,
-      arms: false,
-      face: false,
-      headwear: false,
-      nonce1: BigNumber.from(nonce1),
-      nonce2: BigNumber.from(nonce2)
+    const token2Values = await blockheads.layerValues(token2)
+    const token1BodyBefore = await blockheads.bodyIndex(token1);
+    // Create a swap signature representing the final state where `otherAccount` requests
+    // the body index of token 1.
+    const signature = await createSwapSignature(otherAccount, blockheads.address, token2, {
+      background: token2Values.background,
+      body: token1BodyBefore, // Take the body value from token1
+      head: token2Values.head,
+      arms: token2Values.arms,
+      face: token2Values.face,
+      headwear: token2Values.headwear,
+      nonce: token2Values.nonce + 1, // Since the signature should be for the final state, we need to use the incremented nonce,
     })
     await blockheads.swapPartsCrossUser(
       token1,
       token2,
       signature,
       false,
-      false,
-      false,
       true,
+      false,
+      false,
       false,
       false
     );
-
     await expectRevert.unspecified(blockheads.swapPartsCrossUser(
       token1,
       token2,
       signature,
       false,
-      false,
-      false,
       true,
+      false,
+      false,
       false,
       false
     ));
@@ -295,41 +288,38 @@ describe("Blockheads", function () {
       mainAccount.address,
       0
     );
+    // Bump the nonce here so the nonces are different and we actually test that, rather than
+    // them both being 0 and not being tested
+    await blockheads.bumpNonce(token1)
     const token2 = await blockheads.tokenOfOwnerByIndex(
       otherAccount.address,
       0
     );
+    const token2Values = await blockheads.layerValues(token2)
     let token1HeadBefore = await blockheads.headIndex(token1);
-    let token2HeadBefore = await blockheads.headIndex(token2);
-    const token1BodyBefore = await blockheads.bodyIndex(token1);
-    const token2BodyBefore = await blockheads.bodyIndex(token2);
-    const nonce1 = (await blockheads.overrides.call(otherAccount, token1)).nonce
-    const nonce2 = (await blockheads.overrides.call(otherAccount, token2)).nonce
-    // Signature signs to swap arms but below we'll swap head too, and that should be rejected
-    const signature = await createSwapSignature(otherAccount, blockheads.address, token2, token1, {
-      background: false,
-      body: false,
-      head: false,
-      arms: true,
-      face: false,
-      headwear: false,
-      nonce1, nonce2
-    })
+    let token1BodyBefore = await blockheads.bodyIndex(token2);
+    // Signature signs to swap body but below we'll swap head too, and that should be rejected
+    const desiredState = {
+      background: token2Values.background,
+      body: token1BodyBefore, // Take the body value from token1
+      head: token1HeadBefore,
+      arms: token2Values.arms,
+      face: token2Values.face,
+      headwear: token2Values.headwear,
+      nonce: token2Values.nonce,
+    }
+    const signature = await createSwapSignature(otherAccount, blockheads.address, token2, desiredState)
     await expectRevert.unspecified(blockheads.swapPartsCrossUser(
       token1,
       token2,
       signature,
       false,
       true,
-      false,
       true,
+      false,
       false,
       false
     ));
-    let token1HeadAfter = await blockheads.headIndex(token1);
-    let token2HeadAfter = await blockheads.headIndex(token2);
-    expect(token1HeadAfter).to.equal(token1HeadBefore);
-    expect(token2HeadAfter).to.equal(token2HeadBefore);
   })
 
   it("Should allow swapping parts between two owned tokens", async function () {

--- a/test/blockheads-test.ts
+++ b/test/blockheads-test.ts
@@ -191,11 +191,15 @@ describe("Blockheads", function () {
       mainAccount.address,
       0
     );
+    // Bump the nonce here so the nonces are different and we actually test that, rather than
+    // them both being 0 and not being tested
+    await blockheads.bumpNonce(token1)
     const token2 = await blockheads.tokenOfOwnerByIndex(
       otherAccount.address,
       0
     );
-    const nonce = (await blockheads.overrides.call(otherAccount, token1)).nonce
+    const nonce1 = (await blockheads.overrides.call(otherAccount, token1)).nonce
+    const nonce2 = (await blockheads.overrides.call(otherAccount, token2)).nonce
     let token1HeadBefore = await blockheads.headIndex(token1);
     let token2HeadBefore = await blockheads.headIndex(token2);
     const token1BodyBefore = await blockheads.bodyIndex(token1);
@@ -207,7 +211,8 @@ describe("Blockheads", function () {
       arms: false,
       face: false,
       headwear: false,
-      nonce: BigNumber.from(nonce)
+      nonce1: BigNumber.from(nonce1),
+      nonce2: BigNumber.from(nonce2)
     })
     await blockheads.swapPartsCrossUser(
       token1,
@@ -222,8 +227,6 @@ describe("Blockheads", function () {
     );
     let token1HeadAfter = await blockheads.headIndex(token1);
     let token2HeadAfter = await blockheads.headIndex(token2);
-    const token1BodyAfter = await blockheads.bodyIndex(token1);
-    const token2BodyAfter = await blockheads.bodyIndex(token2);
     expect(token1HeadAfter).to.equal(token2HeadBefore);
     expect(token2HeadAfter).to.equal(token1HeadBefore);
   })
@@ -238,11 +241,15 @@ describe("Blockheads", function () {
       mainAccount.address,
       0
     );
+    // Bump the nonce here so the nonces are different and we actually test that, rather than
+    // them both being 0 and not being tested
+    await blockheads.bumpNonce(token1)
     const token2 = await blockheads.tokenOfOwnerByIndex(
       otherAccount.address,
       0
     );
-    const nonce = (await blockheads.overrides.call(otherAccount, token1)).nonce
+    const nonce1 = (await blockheads.overrides.call(otherAccount, token1)).nonce
+    const nonce2 = (await blockheads.overrides.call(otherAccount, token2)).nonce
     const signature = await createSwapSignature(otherAccount, blockheads.address, token2, token1, {
       background: false,
       body: false,
@@ -250,7 +257,8 @@ describe("Blockheads", function () {
       arms: false,
       face: false,
       headwear: false,
-      nonce: BigNumber.from(nonce)
+      nonce1: BigNumber.from(nonce1),
+      nonce2: BigNumber.from(nonce2)
     })
     await blockheads.swapPartsCrossUser(
       token1,
@@ -295,7 +303,8 @@ describe("Blockheads", function () {
     let token2HeadBefore = await blockheads.headIndex(token2);
     const token1BodyBefore = await blockheads.bodyIndex(token1);
     const token2BodyBefore = await blockheads.bodyIndex(token2);
-    const nonce = (await blockheads.overrides.call(otherAccount, token1)).nonce
+    const nonce1 = (await blockheads.overrides.call(otherAccount, token1)).nonce
+    const nonce2 = (await blockheads.overrides.call(otherAccount, token2)).nonce
     // Signature signs to swap arms but below we'll swap head too, and that should be rejected
     const signature = await createSwapSignature(otherAccount, blockheads.address, token2, token1, {
       background: false,
@@ -304,7 +313,7 @@ describe("Blockheads", function () {
       arms: true,
       face: false,
       headwear: false,
-      nonce
+      nonce1, nonce2
     })
     await expectRevert.unspecified(blockheads.swapPartsCrossUser(
       token1,

--- a/test/swapSigner.ts
+++ b/test/swapSigner.ts
@@ -1,22 +1,23 @@
 import { BigNumber } from "@ethersproject/bignumber";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
+// SwapData indicates the final desired outcome of a swap.  Put the new index
+// you want for any layer, and your existing index for any existing layers.
+// This will be used to ensure the final result of a swap is what you wanted.
 export type SwapData = {
-    background: boolean;
-    body: boolean;
-    arms: boolean;
-    head: boolean;
-    face: boolean;
-    headwear: boolean;
-    nonce1: BigNumber;
-    nonce2: BigNumber;
+    background: number;
+    body: number;
+    arms: number;
+    head: number;
+    face: number;
+    headwear: number;
+    nonce: number;
 }
 
 export async function createSwapSignature(
   signer: SignerWithAddress,
   contractAddress: string,
   tokenId: BigNumber,
-  counterTokenId: BigNumber,
   swaps: SwapData
 ) {
   const chainId = await signer.getChainId();
@@ -28,23 +29,20 @@ export async function createSwapSignature(
   };
   const types = {
     Swap: [
-        { name: "ownersToken", type: "uint256" },
-        { name: "otherToken", type: "uint256"},
-        { name: "background", type: "bool"},
-        { name: "body", type: "bool"},
-        { name: "arms", type: "bool"},
-        { name: "head", type: "bool"},
-        { name: "face", type: "bool"},
-        { name: "headwear", type: "bool"},
-        { name: "nonce1", type: "uint16"},
-        { name: "nonce2", type: "uint16"},
+        { name: "tokenId", type: "uint256" },
+        { name: "background", type: "uint32"},
+        { name: "body", type: "uint32"},
+        { name: "arms", type: "uint32"},
+        { name: "head", type: "uint32"},
+        { name: "face", type: "uint32"},
+        { name: "headwear", type: "uint32"},
+        { name: "nonce", type: "uint16"},
     ],
   };
 
   const sig = await signer._signTypedData(domain, types, {
-    ownersToken: tokenId,
-    otherToken: counterTokenId,
-    ...swaps
+    tokenId,
+    ...swaps,
   });
   return sig
 }

--- a/test/swapSigner.ts
+++ b/test/swapSigner.ts
@@ -8,6 +8,7 @@ export type SwapData = {
     head: boolean;
     face: boolean;
     headwear: boolean;
+    nonce: BigNumber;
 }
 
 export async function createSwapSignature(
@@ -34,7 +35,7 @@ export async function createSwapSignature(
         { name: "head", type: "bool"},
         { name: "face", type: "bool"},
         { name: "headwear", type: "bool"},
-        // { name: "nonce", type: "uint16"}
+        { name: "nonce", type: "uint16"}
 
     ],
   };

--- a/test/swapSigner.ts
+++ b/test/swapSigner.ts
@@ -1,0 +1,30 @@
+import { BigNumber } from "@ethersproject/bignumber";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+export async function createSwapSignature(
+  signer: SignerWithAddress,
+  contractAddress: string,
+  tokenId: BigNumber,
+  counterTokenId: BigNumber,
+) {
+  const chainId = await signer.getChainId();
+  const domain = {
+    name: "WhitelistToken",
+    version: "1",
+    chainId: chainId,
+    verifyingContract: contractAddress,
+  };
+
+  const types = {
+    Swap: [
+        { name: "ownersToken", type: "uint256" },
+        { name: "otherToken", type: "uint256"}
+    ],
+  };
+
+  const sig = await signer._signTypedData(domain, types, {
+    ownersToken: tokenId,
+    otherToken: counterTokenId
+  });
+  return sig
+}

--- a/test/swapSigner.ts
+++ b/test/swapSigner.ts
@@ -1,30 +1,48 @@
 import { BigNumber } from "@ethersproject/bignumber";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
+export type SwapData = {
+    background: boolean;
+    body: boolean;
+    arms: boolean;
+    head: boolean;
+    face: boolean;
+    headwear: boolean;
+}
+
 export async function createSwapSignature(
   signer: SignerWithAddress,
   contractAddress: string,
   tokenId: BigNumber,
   counterTokenId: BigNumber,
+  swaps: SwapData
 ) {
   const chainId = await signer.getChainId();
   const domain = {
-    name: "WhitelistToken",
+    name: "BlockheadsSwap",
     version: "1",
     chainId: chainId,
     verifyingContract: contractAddress,
   };
-
   const types = {
     Swap: [
         { name: "ownersToken", type: "uint256" },
-        { name: "otherToken", type: "uint256"}
+        { name: "otherToken", type: "uint256"},
+        { name: "background", type: "bool"},
+        { name: "body", type: "bool"},
+        { name: "arms", type: "bool"},
+        { name: "head", type: "bool"},
+        { name: "face", type: "bool"},
+        { name: "headwear", type: "bool"},
+        // { name: "nonce", type: "uint16"}
+
     ],
   };
 
   const sig = await signer._signTypedData(domain, types, {
     ownersToken: tokenId,
-    otherToken: counterTokenId
+    otherToken: counterTokenId,
+    ...swaps
   });
   return sig
 }

--- a/test/swapSigner.ts
+++ b/test/swapSigner.ts
@@ -8,7 +8,8 @@ export type SwapData = {
     head: boolean;
     face: boolean;
     headwear: boolean;
-    nonce: BigNumber;
+    nonce1: BigNumber;
+    nonce2: BigNumber;
 }
 
 export async function createSwapSignature(
@@ -35,8 +36,8 @@ export async function createSwapSignature(
         { name: "head", type: "bool"},
         { name: "face", type: "bool"},
         { name: "headwear", type: "bool"},
-        { name: "nonce", type: "uint16"}
-
+        { name: "nonce1", type: "uint16"},
+        { name: "nonce2", type: "uint16"},
     ],
   };
 


### PR DESCRIPTION
Currently we only allow parts to be swapped between tokens owned by the same user.  This creates unnecessary ergonomic, trust, and gas cost issues as you'll need to send someone else your token to perform the swap and trust them to send it back.  We could write a trustless swapping contract but that would incur even more gas fees, and you would lose access to the token while its out for a swap.

~~Instead, we can utilize EIP712 signatures and allow userA to send a signature approving a swap with userB, and then userB can submit the swap transaction with that signature and the swap will be performed.~~

Instead we can utilize EIP712 signatures and allow a user to create a signature for a desired result of a swap, and then any user can use that signature to fulfill the swap.  The signature will encode what the final traits should be, and then any token that can swap parts to make that happen can perform the swap, and we'll assert at the end that the final state matches what the signature desired.

The way this would work in practice is we'd have a swapping frontend where you would create a swap and confirm a signature (not a transaction) with metamask.  This would generate a link that you can send over discord or whatever to the owner of the token you want to swap with, and allow them to perform the swap. 

The signature scheme ensures that only the properties approved can be swapped, and that it can only be used once.  If anything else is done the signature check will fail and the tx will revert.